### PR TITLE
Refactor scenario configuration and CRM import

### DIFF
--- a/src/pynoodle/scenario.py
+++ b/src/pynoodle/scenario.py
@@ -125,11 +125,12 @@ class Scenario:
         self.graph: dict[str, ScenarioNode] = {}
         
         # - Firstly, create all nodes
-        module_root = f'{config.module_root}.' if config.module_root else ''
+        module_prefix = f'{config.module_prefix}.' if config.module_prefix else ''
+        module_postfix = f'{config.module_postfix}' if config.module_postfix else ''
         for node_description in config.scenario_nodes:
             node = ScenarioNode(
                 name=node_description.name,
-                module=module_root + node_description.name,
+                module=module_prefix + node_description.name + module_postfix,
                 dependencies=[]
             )
             self.graph[node_description.name] = node

--- a/src/pynoodle/scene/scene_node.py
+++ b/src/pynoodle/scene/scene_node.py
@@ -113,7 +113,7 @@ class SceneNode(ISceneNode[T]):
         self._access_level = access_level
         self._crm_params = record.launch_params
         self._crm_class = record.scenario_node.crm_class
-        self._import_script = f'from {record.scenario_node.module} import CRM\n'
+        self._import_script = f'from {record.scenario_node.module} import RAW\n'
         self._lock = RWLock(self._node_key, access_mode, timeout, retry_interval)
     
     @property

--- a/src/pynoodle/scene/server_template.py
+++ b/src/pynoodle/scene/server_template.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     server_address: str = args.server_address
     crm_params = json.loads(args.params) if args.params else {}
 
-    crm = CRM(**crm_params)
+    crm = RAW.CRM(**crm_params)
     server = cc.rpc.Server(server_address, crm, node_key)
 
     logger.info(f'Starting CRM Server for node {node_key}...')

--- a/src/pynoodle/schemas/scenario.py
+++ b/src/pynoodle/schemas/scenario.py
@@ -5,5 +5,6 @@ class ScenarioNodeDescription(BaseModel):
     dependencies: list[str] | None = None
 
 class ScenarioConfiguration(BaseModel):
-    module_root: str | None = None
+    module_prefix: str | None = None
+    module_postfix: str | None = None
     scenario_nodes: list[ScenarioNodeDescription]

--- a/tests/scenario.config.yaml
+++ b/tests/scenario.config.yaml
@@ -1,4 +1,5 @@
-module_root: tests.crms
+module_prefix: tests.crms
+module_postfix: null
 scenario_nodes:
   - name: names
   - name: hello


### PR DESCRIPTION
Update scenario configuration to use `module_prefix` and `module_postfix` instead of `module_root`, and change CRM import to use `RAW.CRM` in relevant components.