### PR TITLE
Update .gitignore for consistency in resource naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,6 @@ __marimo__/
 .DS_Store?
 *.db
 *.json
-resources/
+resource/
 tests/module/hello/
 tests/module/names/


### PR DESCRIPTION
Change 'resources/' to 'resource/' in .gitignore to maintain consistency across the project.