### PR TITLE
Refactor parent key retrieval using utility function

### DIFF
--- a/src/pynoodle/utils.py
+++ b/src/pynoodle/utils.py
@@ -1,0 +1,7 @@
+def get_parent_key(node_key: str) -> str:
+    # Format node_key to ensure it starts with '.'
+    if node_key[0] != '.':
+        node_key = '.' + node_key
+    
+    parent_key = '.'.join(node_key.split('.')[:-1])
+    return parent_key if parent_key else '.'

--- a/tests/local.py
+++ b/tests/local.py
@@ -10,7 +10,7 @@ from pynoodle import noodle, NOODLE_INIT, NOODLE_TERMINATE
 
 logging.basicConfig(level=logging.INFO)
 
-NODE_KEY = 'root.names'
+NODE_KEY = '.names'
 # NODE_KEY = 'http://127.0.0.1:8000::nameSet'
 
 if __name__ == '__main__':
@@ -18,11 +18,8 @@ if __name__ == '__main__':
     
     print('\n----- Mount nodes ------\n')
     
-    # Mount local node: root
-    noodle.mount('root')
-    
-    # Mount node: root.names
-    if NODE_KEY == 'root.names':
+    # Mount node: .names
+    if NODE_KEY == '.names':
         noodle.mount(NODE_KEY, 'names')
     
     print('\n----- Access node ------\n')
@@ -66,10 +63,9 @@ if __name__ == '__main__':
     
     noodle.unlink(NODE_KEY, lock_id)
 
-    if NODE_KEY == 'root.names':
+    if NODE_KEY == '.names':
         print('\n----- Unmount nodes ------\n')
         
-        noodle.unmount('root.names')
-        noodle.unmount('root')
+        noodle.unmount('.names')
     
     NOODLE_TERMINATE()


### PR DESCRIPTION
Refactor the retrieval of parent keys in various functions to utilize the new `get_parent_key` utility function, improving code readability and maintainability. Additionally, ensure the root node is created if it doesn't exist during initialization.