### PR TITLE
feat(node): exclude pull_from and push_to endpoints from schema

### DIFF
--- a/src/pynoodle/endpoints/node.py
+++ b/src/pynoodle/endpoints/node.py
@@ -170,7 +170,7 @@ def push_node(template_name: str, source_node_key: str, target_node_key: str):
         logger.error(message)
         raise HTTPException(status_code=500, detail=message)
 
-@router.post('/pull_from')
+@router.post('/pull_from', include_in_schema=False)
 def pull_node(template_name: str, target_node_key: str, source_node_key:str, chunk_data:str, chunk_index:int, is_last_chunk: bool):
     try:
         source_temp_path = settings.MEMORY_TEMP_PATH / 'push_cache' / f'{target_node_key}.tar.gz'
@@ -322,7 +322,7 @@ def packing(node_key: str):
         logger.error(message)
         raise HTTPException(status_code=500, detail=message)
 
-@router.get('/push_to')
+@router.get('/push_to', include_in_schema=False)
 def push_to(node_key: str,chunk_index: int = 0, chunk_size: int = 1024*1024):
     try:        
         source_temp_path = settings.MEMORY_TEMP_PATH / 'pull_cache' / f"{node_key.replace('.', '_')}.tar.gz"

--- a/tests/remote.py
+++ b/tests/remote.py
@@ -21,8 +21,6 @@ logging.basicConfig(level=logging.INFO)
 async def lifespan(app: FastAPI):
     NOODLE_INIT(app)
 
-    noodle.mount('root')
-
     noodle.mount('nameSet', 'names')
     with noodle.connect(INames, 'nameSet', 'lw') as names:
         names.add_name('Alice')


### PR DESCRIPTION
This pull request makes minor adjustments to the API schema exposure and test setup. The main changes are hiding two endpoints from the OpenAPI schema and a small update to the test mounting logic.

API endpoint visibility:

* The `/pull_from` POST endpoint in `src/pynoodle/endpoints/node.py` is now hidden from the OpenAPI schema by setting `include_in_schema=False`.
* The `/push_to` GET endpoint in `src/pynoodle/endpoints/node.py` is also hidden from the OpenAPI schema with `include_in_schema=False`.

Test code update:

* In `tests/remote.py`, the mounting of the `'root'` node was removed from the test setup, possibly to streamline or correct the test environment.